### PR TITLE
* Fix bug with copy array in shallowCopy.

### DIFF
--- a/spec/helpers.spec.ts
+++ b/spec/helpers.spec.ts
@@ -66,6 +66,20 @@ describe('helpers', () => {
             expect(newState.id).toBe('newId');
             expect(newState.subObject).toEqual({ id: 'newSubId' });
         });
+
+        it('Copy nested array ', () => {
+            let newState = h.shallowCopy(aState);
+            newState.list = h.shallowCopy(newState.list);
+
+            expect(Array.isArray(newState.list)).toBe(true);
+            expect(newState.list.length).toBe(aState.list.length);
+
+            for (let key in newState.list) {
+                if (newState.list.hasOwnProperty(key) && typeof key !== 'function') {
+                    expect(newState.list[key]).toBe(aState.list[key]);
+                }
+            }
+        });
     });
 });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,9 +1,13 @@
-export function shallowCopy<T>(source: T, callback: (target: T) => void | T = (t: T) => { }): T {
-    let target = <T>{};
-    for (var property in source)
-        if (source.hasOwnProperty(property))
+export function shallowCopy<T>(source: T, callback: (target: T) => void | T = (t: T) => { ; }): T {
+    let target: T = Array.isArray(source) ? <T><any>[...source] : <T>{};
+
+    for (var property in source) {
+        // target.hasOwnProperty(property) to prevent applying arrays properties once again
+        if (!target.hasOwnProperty(property) && source.hasOwnProperty(property)) {
             target[property] = source[property];
-    let result = callback(target);
+        }
+    }
+
+    let result: void | T = callback(target);
     return <T>result || target;
 };
-


### PR DESCRIPTION
Old function:
When shalowCopy copy array, it create new object and copy array items as property to the object.

new function:
If shalowCopy detect array, it create copy of array and then copy all injected properties to new array.