### PR TITLE
Parameterlessaction

### DIFF
--- a/spec/actionFactory.spec.ts
+++ b/spec/actionFactory.spec.ts
@@ -71,11 +71,11 @@ describe('actionFactory', () => {
     describe('createAction', () => {
         describe('when action threw during handling and catching have not been enabled', () => {
             let renderCallback: () => void;
-            let throwingAction: af.IAction<{}>;
+            let throwingAction: af.IParamLessAction;
             beforeEach(() => {
                 renderCallback = jasmine.createSpy('render');
                 af.bootstrap(renderCallback, false);
-                throwingAction = af.createAction(NestedCursorTestFixture, () => {
+                throwingAction = af.createParamLessAction(NestedCursorTestFixture, () => {
                     throw 'MyDummyException';
                 });
             });
@@ -87,11 +87,11 @@ describe('actionFactory', () => {
 
         describe('when action threw during handling and catching have been enabled', () => {
             let renderCallback: () => void;
-            let throwingAction: af.IAction<{}>;
+            let throwingAction: af.IParamLessAction;
             beforeEach(() => {
                 renderCallback = jasmine.createSpy('render');
                 af.bootstrap(renderCallback, true);
-                throwingAction = af.createAction(NestedCursorTestFixture, () => {
+                throwingAction = af.createParamLessAction(NestedCursorTestFixture, () => {
                     throw 'MyDummyException';
                 });
             });
@@ -115,7 +115,7 @@ describe('actionFactory', () => {
 
             it('throws if key does not exist', () => {
                 expect(() => {
-                    let testAction = af.createAction(NestedCursorTestFixture, () => { return { state: 'new nested state' }; });
+                    let testAction = af.createParamLessAction(NestedCursorTestFixture, () => { return { state: 'new nested state' }; });
                     testAction();
                 }).toThrow('Render callback must be set before first usage through bootstrap(defaultState, () => { yourRenderCallback(); }).');
             });
@@ -132,7 +132,7 @@ describe('actionFactory', () => {
             it('does not report current state when state has not been changed.', () => {
                 givenStore(aState('nestedStateValue'));
 
-                af.createAction(NestedCursorTestFixture, (state: INestedState) => state)();
+                af.createParamLessAction(NestedCursorTestFixture, (state: INestedState) => state)();
 
                 expect(debugCallback).not.toHaveBeenCalledWith('Global state has been changed.', undefined);
             });
@@ -141,7 +141,7 @@ describe('actionFactory', () => {
                 let newState = { state: 'newValue' };
                 givenStore(aState('nestedStateValue'));
 
-                af.createAction(NestedCursorTestFixture, () => newState)();
+                af.createParamLessAction(NestedCursorTestFixture, () => newState)();
 
                 expect(debugCallback).toHaveBeenCalledWith('Global state has been changed.', undefined);
             });
@@ -149,7 +149,7 @@ describe('actionFactory', () => {
             it('does not call render callback when state has not been changed', () => {
                 givenStore(aState('nestedStateValue'));
 
-                let testAction = af.createAction(NestedCursorTestFixture, (state: INestedState) => state);
+                let testAction = af.createParamLessAction(NestedCursorTestFixture, (state: INestedState) => state);
                 testAction();
 
                 expect(renderCallback).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe('actionFactory', () => {
             it('calls render callback when state has been changed', () => {
                 givenStore(aState('nestedStateValue'));
 
-                let testAction = af.createAction(NestedCursorTestFixture, () => { return { state: 'newValue' }; })
+                let testAction = af.createParamLessAction(NestedCursorTestFixture, () => { return { state: 'newValue' }; })
                 testAction();
 
                 expect(renderCallback).toHaveBeenCalled();
@@ -167,16 +167,16 @@ describe('actionFactory', () => {
             it('calls nested actions', () => {
                 givenStore(aState('value'));
 
-                const nestedAction2 = af.createAction(NestedCursorTestFixture, (state: INestedState) => {
+                const nestedAction2 = af.createParamLessAction(NestedCursorTestFixture, (state: INestedState) => {
                     return { state: `${state.state} -> newValueFromNestedAction2` };
                 });
 
-                const nestedAction = af.createAction(NestedCursorTestFixture, (state: INestedState) => {
+                const nestedAction = af.createParamLessAction(NestedCursorTestFixture, (state: INestedState) => {
                     nestedAction2();
                     return { state: `${state.state} -> newValueFromNestedAction` };
                 });
 
-                af.createAction(NestedCursorTestFixture, () => {
+                af.createParamLessAction(NestedCursorTestFixture, () => {
                     nestedAction();
                     return { state: 'newValue' };
                 })();
@@ -188,7 +188,7 @@ describe('actionFactory', () => {
             it('does not throw on immutability violation in no debug mode', () => {
                 d.bootstrap(undefined);
                 givenStore(aState('nestedStateValue'));
-                const testAction = af.createAction(SomeCursorTestFixture, (state: ISomeState) => {
+                const testAction = af.createParamLessAction(SomeCursorTestFixture, (state: ISomeState) => {
                     state.nested.state = state.nested.state + 'newValue';
                     return state;
                 });
@@ -204,7 +204,7 @@ describe('actionFactory', () => {
         describe('when renderCallback has not been set', () => {
             it('throws if key does not exist', () => {
                 expect(() => {
-                    let testAction = af.createActions({
+                    let testAction = af.createParamLessActions({
                         cursor: NestedCursorTestFixture,
                         handler: (state: INestedState): INestedState => state
                     });
@@ -224,7 +224,7 @@ describe('actionFactory', () => {
             it('does not call render callback when all states have not been changed', () => {
                 givenStore(aState('nestedStateValue'));
 
-                let testAction = af.createActions(
+                let testAction = af.createParamLessActions(
                     {
                         cursor: NestedCursorTestFixture,
                         handler: (state: INestedState): INestedState => state
@@ -240,7 +240,7 @@ describe('actionFactory', () => {
             it('calls render callback when one of states has been changed', () => {
                 givenStore(aState('nestedStateValue'));
 
-                let testAction = af.createActions(
+                let testAction = af.createParamLessActions(
                     {
                         cursor: SomeCursorTestFixture,
                         handler: (state: ISomeState): ISomeState => { return { nested: state.nested, state: 'newStateValue' } }

--- a/src/actionFactory.ts
+++ b/src/actionFactory.ts
@@ -13,60 +13,100 @@ export const bootstrap = (onStateChanged: (() => void) | null, withExceptionHand
 };
 
 export interface IAction<T> {
-    (param?: T): void;
+    (param: T): void;
 }
 
-export type IActionHandler<TState extends s.IState, TParams> = (state: TState, t?: TParams) => TState;
+export interface IParamLessAction {
+    (): void;
+}
+
+export type IActionHandler<TState extends s.IState, TParams> = (state: TState, t: TParams) => TState;
+
+export type IParamLessActionHandler<TState extends s.IState> = (state: TState) => TState;
+
+type IInternalActionHandler<TState extends s.IState> = (state: TState) => TState;
 
 function defaultHandler<TValue>(_oldValue: TValue, newValue: TValue) { return newValue; }
 
 export const createAction = <TState extends s.IState, TParams>(cursor: s.ICursor<TState> | s.ICursorFactory<TState, TParams>, handler: IActionHandler<TState, TParams> = defaultHandler)
     : IAction<TParams> => {
-    return <IAction<TParams>>((params?: TParams): void => {
+    return <IAction<TParams>>((params: TParams): void => {
         if (stateChanged === null)
             throw 'Render callback must be set before first usage through bootstrap(defaultState, () => { yourRenderCallback(); }).';
 
-        if (changeStateWithQueue(unifyCursor<TState, TParams>(cursor, params), handler, params)) {
+        if (changeStateWithQueue(unifyCursor<TState, TParams>(cursor, params), (state) => handler(state, params))) {
             stateChanged();
             d.log('Rendering invoked...');
         }
     });
-}
+};
 
-function unifyCursor<TState extends s.IState, TParams>(cursor: s.ICursor<TState> | s.ICursorFactory<TState, TParams>, params: TParams | undefined): s.ICursor<TState> {
+export const createParamLessAction = <TState extends s.IState>(cursor: s.ICursor<TState>, handler: IParamLessActionHandler<TState>)
+    : IParamLessAction => {
+    return <IParamLessAction>((): void => {
+        if (stateChanged === null)
+            throw 'Render callback must be set before first usage through bootstrap(defaultState, () => { yourRenderCallback(); }).';
+
+        if (changeStateWithQueue(cursor, handler)) {
+            stateChanged();
+            d.log('Rendering invoked...');
+        }
+    });
+};
+
+function unifyCursor<TState extends s.IState, TParams>(cursor: s.ICursor<TState> | s.ICursorFactory<TState, TParams>, params: TParams): s.ICursor<TState> {
     return (<s.ICursorFactory<TState, TParams>>cursor).create instanceof Function ? (<s.ICursorFactory<TState, TParams>>cursor).create(params) : <s.ICursor<TState>>cursor;
 }
 
 export interface IPair<TState extends s.IState, TParam> {
     cursor: s.ICursor<TState>;
-    handler: (state: TState, t?: TParam) => TState
+    handler: (state: TState, t: TParam) => TState
 }
 
 export const createActions = <TState extends s.IState, TParams>(...pairs: IPair<TState, TParams>[]) => {
-    return <IAction<TParams>>((params?: TParams) => {
+    return <IAction<TParams>>((params: TParams) => {
         if (stateChanged === null)
             throw 'Render callback must be set before first usage through bootstrap(defaultState, () => { yourRenderCallback(); }).';
         let changed = false;
         for (var i in pairs)
             if (pairs.hasOwnProperty(i)) {
                 let pair = pairs[i];
-                if (changeStateWithQueue(pair.cursor, pair.handler, params))
+                if (changeStateWithQueue(pair.cursor, (state) => pair.handler(state, params)))
                     changed = true;
             }
         changed && stateChanged();
     });
-}
+};
 
-interface IQueuedHandling<TState extends s.IState, TParams> {
+export interface IParamLessPair<TState extends s.IState> {
     cursor: s.ICursor<TState>;
-    handler: IActionHandler<TState, TParams>;
-    params: TParams;
+    handler: (state: TState) => TState
 }
 
-let queueOfHandlers: IQueuedHandling<s.IState, Object>[] = [];
-function changeStateWithQueue<TState extends s.IState, TParams>(cursor: s.ICursor<TState>, handler: IActionHandler<TState, TParams>, params: TParams)
+export const createParamLessActions = <TState extends s.IState>(...pairs: IParamLessPair<TState>[]) => {
+    return <IParamLessAction>(() => {
+        if (stateChanged === null)
+            throw 'Render callback must be set before first usage through bootstrap(defaultState, () => { yourRenderCallback(); }).';
+        let changed = false;
+        for (var i in pairs)
+            if (pairs.hasOwnProperty(i)) {
+                let pair = pairs[i];
+                if (changeStateWithQueue(pair.cursor, pair.handler))
+                    changed = true;
+            }
+        changed && stateChanged();
+    });
+};
+
+interface IQueuedHandling<TState extends s.IState> {
+    cursor: s.ICursor<TState>;
+    handler: IInternalActionHandler<TState>;
+}
+
+let queueOfHandlers: IQueuedHandling<s.IState>[] = [];
+function changeStateWithQueue<TState extends s.IState>(cursor: s.ICursor<TState>, handler: IInternalActionHandler<TState>)
     : boolean {
-    queueOfHandlers.push({ cursor, handler, params });
+    queueOfHandlers.push({ cursor, handler });
     if (queueOfHandlers.length > 1)
         return false;
     let isStateChanged = false;
@@ -74,12 +114,12 @@ function changeStateWithQueue<TState extends s.IState, TParams>(cursor: s.ICurso
         let n = queueOfHandlers[0];
         if (h.isFunction(exceptionHandling) ? exceptionHandling() : exceptionHandling)
             try {
-                isStateChanged = changeState(n.cursor, n.handler, n.params) || isStateChanged;
+                isStateChanged = changeState(n.cursor, n.handler) || isStateChanged;
             } catch (error) {
                 d.log('Error in action handling: ', error);
             }
         else
-            isStateChanged = changeState(n.cursor, n.handler, n.params) || isStateChanged;
+            isStateChanged = changeState(n.cursor, n.handler) || isStateChanged;
 
         queueOfHandlers.shift();
     }
@@ -87,10 +127,10 @@ function changeStateWithQueue<TState extends s.IState, TParams>(cursor: s.ICurso
     return isStateChanged;
 }
 
-function changeState<TState extends s.IState, TParams>(cursor: s.ICursor<TState>, handler: IActionHandler<TState, TParams>, params: TParams)
+function changeState<TState extends s.IState>(cursor: s.ICursor<TState>, handler: IInternalActionHandler<TState>)
     : boolean {
     let oldState = s.getState(cursor);
-    let newState = handler(oldState, params);
+    let newState = handler(oldState);
     if (oldState === newState)
         return false;
     s.setState(cursor, newState);

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,7 @@ export interface ICursor<TState extends IState> {
 }
 
 export interface ICursorFactory<TState, TParms> {
-    create(data?: TParms): ICursor<TState>;
+    create(data: TParms): ICursor<TState>;
 }
 
 let state: IState | null = null;


### PR DESCRIPTION
Hello,
I created a parameterless action and action with a parameter set that are mandatory. When turned on strictNullChecks is now needed to validate all parameters an undefined handler. After this change is clear whether the handler has parameters and their type.
