### PR TITLE
Changes for backward compatibility

### DIFF
--- a/spec/helpers.spec.ts
+++ b/spec/helpers.spec.ts
@@ -1,5 +1,5 @@
 import * as h from '../src/helpers';
-import { bootstrap } from "../src/debug";
+import { bootstrap } from '../src/debug';
 
 describe('helpers', () => {
     describe('shallowCopy', () => {
@@ -95,31 +95,31 @@ describe('helpers', () => {
             })
         });
 
-        describe('primitive', () => {
-            it("call callback when called with primitive", () => {
-                const callback = jasmine.createSpy("callback");
-                h.shallowCopy("test", callback);
+        describe('on primitive', () => {
+            it('calls callback', () => {
+                const callback = jasmine.createSpy('callback');
+                h.shallowCopy('test', callback);
 
-                expect(callback).toHaveBeenCalledWith("test");
+                expect(callback).toHaveBeenCalledWith('test');
             });
 
-            it("call debug because of wrong usage", () => {
-                const debug = jasmine.createSpy("debug");
+            it('calls debug because of wrong usage', () => {
+                const debug = jasmine.createSpy('debug');
                 bootstrap(debug);
-                h.shallowCopy("test");
+                h.shallowCopy('test');
                 expect(debug).toHaveBeenCalled();
             });
 
-            it("return value when no callback provided", () => {
-                const returnValue = h.shallowCopy("test");
+            it('returns value when no callback provided', () => {
+                const returnValue = h.shallowCopy('test');
 
-                expect(returnValue).toBe("test");
+                expect(returnValue).toBe('test');
             });
 
-            it("respects returned value from cb", () => {
-                const returnValue = h.shallowCopy("test", (_original: string) => "changed value");
+            it('respects returned value', () => {
+                const returnValue = h.shallowCopy('test', (_original: string) => 'changed value');
 
-                expect(returnValue).toBe("changed value");
+                expect(returnValue).toBe('changed value');
             });
         });
     });

--- a/spec/helpers.spec.ts
+++ b/spec/helpers.spec.ts
@@ -115,6 +115,12 @@ describe('helpers', () => {
 
                 expect(returnValue).toBe("test");
             });
+
+            it("respects returned value from cb", () => {
+                const returnValue = h.shallowCopy("test", (_original: string) => "changed value");
+
+                expect(returnValue).toBe("changed value");
+            });
         });
     });
 

--- a/spec/helpers.spec.ts
+++ b/spec/helpers.spec.ts
@@ -1,4 +1,5 @@
 import * as h from '../src/helpers';
+import { bootstrap } from "../src/debug";
 
 describe('helpers', () => {
     describe('shallowCopy', () => {
@@ -92,6 +93,28 @@ describe('helpers', () => {
                     }
                 }
             })
+        });
+
+        describe('primitive', () => {
+            it("call callback when called with primitive", () => {
+                const callback = jasmine.createSpy("callback");
+                h.shallowCopy("test", callback);
+
+                expect(callback).toHaveBeenCalledWith("test");
+            });
+
+            it("call debug because of wrong usage", () => {
+                const debug = jasmine.createSpy("debug");
+                bootstrap(debug);
+                h.shallowCopy("test");
+                expect(debug).toHaveBeenCalled();
+            });
+
+            it("return value when no callback provided", () => {
+                const returnValue = h.shallowCopy("test");
+
+                expect(returnValue).toBe("test");
+            });
         });
     });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { debug } from "./debug";
 
 export function shallowCopy<T>(source: T, callback?: (target: T) => void | T): T;
 export function shallowCopy<T>(source: T[], callback?: (target: T[]) => void | T[]): T[];
@@ -10,7 +11,12 @@ export function shallowCopy(source: any, callback?: (target: any) => void | any)
     if (typeof source === "object") {
         return objectShallowCopy(source, callback);
     }
-    return source;
+
+    if (debug) {
+        debug("Don't call shallow copy with primitive.");
+    }
+    const result = callback && callback(source);
+    return result || source;
 }
 
 export function objectShallowCopy<T extends Object>(source: T, callback: (target: T) => void | T = (_t: T) => { }): T {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,8 @@
 import { debug } from "./debug";
 
-export function shallowCopy<T>(source: T, callback?: (target: T) => void | T): T;
-export function shallowCopy<T>(source: T[], callback?: (target: T[]) => void | T[]): T[];
-export function shallowCopy(source: any, callback?: (target: any) => void | any): any {
+export function shallowCopy<T>(source: T, callback?: (target: T) => void | T): T {
     if (source instanceof Array) {
-        source = [...source];
+        source = [...source] as unknown as T;
         const result = callback ? callback(source) : undefined;
         return result || source;
     }


### PR DESCRIPTION
Original mutate function
`
(state: string, params: ISetTimeSegmentationData) => {
        return flux.shallowCopy(state, (newState: string) => {
            newState = params.timeSegmentation;
            return newState;
        });
    }
`